### PR TITLE
Feature/fix install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,4 @@ if(ENABLE_TESTS)
 endif()
 
 # Add install options
-include(Install)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/Install.cmake)


### PR DESCRIPTION
We're using `fsmlite` as a `ROS2` (Robot Operating System 2) package's submodule. We are able to compile the package with this fix